### PR TITLE
Adding nexus job to jenkins manifest

### DIFF
--- a/jenkins.yml
+++ b/jenkins.yml
@@ -59,9 +59,26 @@ instance_groups:
   stemcell: default
   networks:
   - name: default
+- name: nexus
+  azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: nexus
+    release: buildstack
+    properties:
+      nexus:
+        admin:
+          password: ((nexus_admin_password))
+  vm_type: default
+  stemcell: default
+  networks:
+  - name: default
 
 variables:
 - name: jenkins_admin_password
   type: password
 - name: jenkins_agent_password
+  type: password
+- name: nexus_admin_password
   type: password


### PR DESCRIPTION
This will be removed once we've updated the concourse pipeline to
deploy using the buildstack deployment manifest