### PR TITLE
Corrected bosh deployment version for devtools

### DIFF
--- a/buildstack.yml
+++ b/buildstack.yml
@@ -175,7 +175,7 @@ releases:
 - name: devtools
   sha1: 7a1effff18a83adb7c9ee504d41a5559a90c25c7
   url: https://github.com/finkit/devtools-boshrelease/releases/download/v2.0.0/devtools-boshrelease-v2.0.0.tgz
-  version: v2.0.0
+  version: 2.0.0
 - name: newrelic-infra-bosh
   sha1: 5be785540118f1b3fab909ba30f64b30e48f76a5
   url: https://github.com/dazjones/newrelic-infra-bosh/releases/download/v0.1.2/newrelic-infra-bosh-0.1.2.tgz


### PR DESCRIPTION
Version must match that in the release