### PR TITLE
Add BOSH Lite settings to director scripts

### DIFF
--- a/iaas-support/bosh-lite-gcp/create-director-override.sh
+++ b/iaas-support/bosh-lite-gcp/create-director-override.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+bosh create-env \
+  ${BBL_STATE_DIR}/bosh-deployment/bosh.yml \
+  --state  ${BBL_STATE_DIR}/vars/bosh-state.json \
+  --vars-store  ${BBL_STATE_DIR}/vars/director-vars-store.yml \
+  --vars-file  ${BBL_STATE_DIR}/vars/director-vars-file.yml \
+  -o  ${BBL_STATE_DIR}/bosh-deployment/gcp/cpi.yml \
+  -o  ${BBL_STATE_DIR}/bosh-deployment/jumpbox-user.yml \
+  -o  ${BBL_STATE_DIR}/bosh-deployment/uaa.yml \
+  -o  ${BBL_STATE_DIR}/bosh-deployment/credhub.yml \
+  -o  ${BBL_STATE_DIR}/bosh-deployment/bosh-lite.yml \
+  -o  ${BBL_STATE_DIR}/bosh-deployment/bosh-lite-runc.yml \
+  -o  ${BBL_STATE_DIR}/bosh-deployment/gcp/bosh-lite-vm-type.yml \
+  -o  ${BBL_STATE_DIR}/bbl-ops-files/gcp/bosh-director-ephemeral-ip-ops.yml \
+  --var-file  gcp_credentials_json="${BBL_GCP_SERVICE_ACCOUNT_KEY_PATH}" \
+  -v  project_id="${BBL_GCP_PROJECT_ID}" \
+  -v  zone="${BBL_GCP_ZONE}" 

--- a/iaas-support/bosh-lite-gcp/delete-director-override.sh
+++ b/iaas-support/bosh-lite-gcp/delete-director-override.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+bosh delete-env \
+  ${BBL_STATE_DIR}/bosh-deployment/bosh.yml \
+  --state  ${BBL_STATE_DIR}/vars/bosh-state.json \
+  --vars-store  ${BBL_STATE_DIR}/vars/director-vars-store.yml \
+  --vars-file  ${BBL_STATE_DIR}/vars/director-vars-file.yml \
+  -o  ${BBL_STATE_DIR}/bosh-deployment/gcp/cpi.yml \
+  -o  ${BBL_STATE_DIR}/bosh-deployment/jumpbox-user.yml \
+  -o  ${BBL_STATE_DIR}/bosh-deployment/uaa.yml \
+  -o  ${BBL_STATE_DIR}/bosh-deployment/credhub.yml \
+  -o  ${BBL_STATE_DIR}/bosh-deployment/bosh-lite.yml \
+  -o  ${BBL_STATE_DIR}/bosh-deployment/bosh-lite-runc.yml \
+  -o  ${BBL_STATE_DIR}/bosh-deployment/gcp/bosh-lite-vm-type.yml \
+  -o  ${BBL_STATE_DIR}/bbl-ops-files/gcp/bosh-director-ephemeral-ip-ops.yml \
+  --var-file  gcp_credentials_json="${BBL_GCP_SERVICE_ACCOUNT_KEY_PATH}" \
+  -v  project_id="${BBL_GCP_PROJECT_ID}" \
+  -v  zone="${BBL_GCP_ZONE}" 


### PR DESCRIPTION
As per the discussion on slack, this is a speculative change to try and provide support for Warden stemcells in devtools-boshrelease. Just to try and make some progress before Tuesday. Please leave if you think it has no value or we should discuss further after the Bank Holiday.

Hopefully it won't be destructive, even if it doesn't work.

It should just add the following settings to the create and delete director scripts:

-o  ${BBL_STATE_DIR}/bosh-deployment/bosh-lite.yml \
-o  ${BBL_STATE_DIR}/bosh-deployment/bosh-lite-runc.yml \
-o  ${BBL_STATE_DIR}/bosh-deployment/gcp/bosh-lite-vm-type.yml \

These files are present in the devtools-boshrelease BBL state.