### PR TITLE
Add ops file for GCP VM types

### DIFF
--- a/iaas-support/bosh-lite-gcp/cloud-config/extra_vm_types.yml
+++ b/iaas-support/bosh-lite-gcp/cloud-config/extra_vm_types.yml
@@ -1,0 +1,17 @@
+- type: replace
+  path: /vm_types?/-
+  value:
+    name: default
+    cloud_properties:
+      machine_type: n1-standard-2
+      root_disk_size_gb: 20
+      root_disk_type: pd-ssd
+
+- type: replace
+  path: /vm_types?/-
+  value:
+    name: large
+    cloud_properties:
+      machine_type: n1-standard-2
+      root_disk_size_gb: 50
+      root_disk_type: pd-ssd


### PR DESCRIPTION
Values taken from bosh-deployment/gcp/cloud-config.
yml.

bosh int cloud-config.yml -o extra_vm_types.yml worked. Presumably we could use a similar "extra"-style ops file for the vm_extensions too?

Dunno why we don't have to specify these ops files in create-director-overrides.sh. Because they affect the cloud config instead?