### PR TITLE
Reduce jenkins-master persistent disk from 100GB to 20GB

### DIFF
--- a/buildstack.yml
+++ b/buildstack.yml
@@ -17,7 +17,7 @@ instance_groups:
   name: jenkins-master
   networks:
   - name: default
-  persistent_disk_pool: 100GB
+  persistent_disk_pool: 20GB
   stemcell: default
   vm_extensions:
   - internet-required


### PR DESCRIPTION
Depends on https://github.com/FINkit/buildstack-deployment-bbl-customisations/pull/18