### PR TITLE
Jenkins pool now on haproxy

### DIFF
--- a/buildstack.yml
+++ b/buildstack.yml
@@ -19,9 +19,6 @@ instance_groups:
   - name: default
   persistent_disk_pool: 100GB
   stemcell: default
-  vm_extensions:
-  - internet-required
-  - jenkins-pool
   vm_type: default
 - azs:
   - z1


### PR DESCRIPTION
Traffic now goes through haproxy before jenkins-master. Removed external ip as not required by jenkins-master